### PR TITLE
correct jBeanBox  singleton config

### DIFF
--- a/src/main/java/com/greenlaw110/di_benchmark/configs/JBeanBoxConfig1.java
+++ b/src/main/java/com/greenlaw110/di_benchmark/configs/JBeanBoxConfig1.java
@@ -3,6 +3,7 @@ package com.greenlaw110.di_benchmark.configs;
 import com.github.drinkjava2.BeanBox;
 import com.github.drinkjava2.BeanBoxContext;
 import com.greenlaw110.di_benchmark.objects.A;
+import com.greenlaw110.di_benchmark.objects.A0;
 import com.greenlaw110.di_benchmark.objects.B;
 import com.greenlaw110.di_benchmark.objects.C;
 import com.greenlaw110.di_benchmark.objects.D1;
@@ -19,7 +20,13 @@ public class JBeanBoxConfig1 {
 			this.setConstructor(A.class, B.class);
 		}
 	}
-
+	
+	public static class A0Box extends BeanBox {
+		{
+			this.setConstructor(A0.class, B.class);
+		}
+	}
+	
 	public static class BBox extends ProtoTypeBox {
 		{ 
 			this.setConstructor(B.class, C.class);

--- a/src/main/java/com/greenlaw110/di_benchmark/configs/JBeanBoxConfig2.java
+++ b/src/main/java/com/greenlaw110/di_benchmark/configs/JBeanBoxConfig2.java
@@ -3,6 +3,7 @@ package com.greenlaw110.di_benchmark.configs;
 import com.github.drinkjava2.BeanBox;
 import com.github.drinkjava2.BeanBoxContext;
 import com.greenlaw110.di_benchmark.objects.A;
+import com.greenlaw110.di_benchmark.objects.A0;
 import com.greenlaw110.di_benchmark.objects.B;
 import com.greenlaw110.di_benchmark.objects.C;
 import com.greenlaw110.di_benchmark.objects.D1;
@@ -18,6 +19,12 @@ public class JBeanBoxConfig2 {
 	public static class ABox extends ProtoTypeBox { 
 		public A create() {
 			return new A(context.getBean(B.class));
+		}
+	}
+	
+	public static class A0Box extends BeanBox { 
+		public A0 create() {
+			return new A0(context.getBean(B.class));
 		}
 	}
 


### PR DESCRIPTION
Hi Green, The singleton exception is because you did not put configuration in JBeanBoxConfig1 and JBeanBoxConfig2, this made it to call non exist 0 parameter constructor. but it's still a bug because it should throw a "configuration not found exception" instead of "circular dependency exception", will fix this bug in next snapshot version. Thank you take time your time to try jBeanBox, it's pretty new no one else used it before. 
