### PR TITLE
Fixes #5 - Upgrade Dagger to version 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,15 +51,9 @@
       <version>2.15</version>
     </dependency>
     <dependency>
-      <groupId>com.squareup.dagger</groupId>
+      <groupId>com.google.dagger</groupId>
       <artifactId>dagger</artifactId>
-      <version>1.2.5</version>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.dagger</groupId>
-      <artifactId>dagger-compiler</artifactId>
-      <version>1.2.5</version>
-      <optional>true</optional>
+      <version>2.12</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -89,10 +83,17 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.5</version>
         <configuration>
           <target>${java.version}</target>
           <source>${java.version}</source>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.dagger</groupId>
+              <artifactId>dagger-compiler</artifactId>
+              <version>2.12</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/com/greenlaw110/di_benchmark/DIFactory.java
+++ b/src/main/java/com/greenlaw110/di_benchmark/DIFactory.java
@@ -19,9 +19,10 @@ import com.greenlaw110.di_benchmark.configs.JBeanBoxConfig1;
 import com.greenlaw110.di_benchmark.configs.JBeanBoxConfig2;
 
 import dagger.Module;
-import dagger.ObjectGraph;
 
 import javax.inject.Provider;
+import javax.inject.Singleton;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -105,15 +106,33 @@ public class DIFactory {
         return genie;
     }
 
-    public static ObjectGraph dagger() {
-        return ObjectGraph.create(new DaggerModule());
+    public static DaggerComponent dagger() {
+        return DaggerDIFactory_DaggerComponent.builder().build();
     }
 
-    @Module(injects = {A.class, A0.class})
+    @Module
     public static class DaggerModule {
         @dagger.Provides
         E e() {
             return new E();
+        }
+    }
+
+    @dagger.Component(modules = DaggerModule.class)
+    @Singleton
+    public interface DaggerComponent {
+        A getA();
+        A0 getA0();
+
+        @SuppressWarnings("unchecked")
+        default <T> T get(Class<T> c) {
+            if (c == A.class) {
+                return (T) getA();
+            }
+            if (c == A0.class) {
+                return (T) getA0();
+            }
+            throw new IllegalArgumentException();
         }
     }
 

--- a/src/main/java/com/greenlaw110/di_benchmark/RuntimeBenchmark.java
+++ b/src/main/java/com/greenlaw110/di_benchmark/RuntimeBenchmark.java
@@ -18,10 +18,9 @@ import org.springframework.context.ApplicationContext;
 
 import com.github.drinkjava2.BeanBoxContext;
 import com.google.inject.Injector;
+import com.greenlaw110.di_benchmark.DIFactory.DaggerComponent;
 import com.greenlaw110.di_benchmark.DIFactory.VanillaContainer;
 import com.greenlaw110.di_benchmark.objects.A;
-
-import dagger.ObjectGraph;
 
 /**
  * Measures bootstrap cost of different DI tools. An iteration includes creating
@@ -37,7 +36,7 @@ public class RuntimeBenchmark {
 		VanillaContainer vanilla = vanilla();
 		Injector guice = guice();
 		Feather feather = Feather.with();
-		ObjectGraph dagger = dagger();
+		DaggerComponent dagger = dagger();
 		MutablePicoContainer pico = pico();
 		Genie genie = genie();
 		BeanBoxContext jbeanboxNormal = jbeanboxNormal();

--- a/src/main/java/com/greenlaw110/di_benchmark/SplitStartupBenchmark.java
+++ b/src/main/java/com/greenlaw110/di_benchmark/SplitStartupBenchmark.java
@@ -16,10 +16,9 @@ import org.springframework.context.ApplicationContext;
 import com.github.drinkjava2.BeanBoxContext;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.greenlaw110.di_benchmark.DIFactory.DaggerComponent;
 import com.greenlaw110.di_benchmark.DIFactory.VanillaContainer;
 import com.greenlaw110.di_benchmark.objects.A;
-
-import dagger.ObjectGraph;
 
 /**
  * Measures bootstrap cost of different DI tools. An iteration includes creating
@@ -63,7 +62,7 @@ public class SplitStartupBenchmark {
 		StopWatch.startAndFetch("Dagger", (start, fetch) -> {
 			for (int i = 0; i < iterations; ++i) {
 				long ms = System.currentTimeMillis();
-				ObjectGraph dagger = dagger();
+				DaggerComponent dagger = dagger();
 				long ms2 = System.currentTimeMillis();
 				start.addAndGet(ms2 - ms);
 				dagger.get(A.class);

--- a/src/main/java/com/greenlaw110/di_benchmark/StartupBenchmark.java
+++ b/src/main/java/com/greenlaw110/di_benchmark/StartupBenchmark.java
@@ -17,10 +17,9 @@ import org.springframework.context.ApplicationContext;
 import com.github.drinkjava2.BeanBoxContext;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.greenlaw110.di_benchmark.DIFactory.DaggerComponent;
 import com.greenlaw110.di_benchmark.DIFactory.VanillaContainer;
 import com.greenlaw110.di_benchmark.objects.A;
-
-import dagger.ObjectGraph;
 
 /**
  * Measures bootstrap cost of different DI tools. An iteration includes creating
@@ -63,7 +62,7 @@ public class StartupBenchmark {
 		});
 		StopWatch.millis("Dagger", () -> {
 			for (int i = 0; i < iterations; ++i) {
-				ObjectGraph dagger = dagger();
+				DaggerComponent dagger = dagger();
 				dagger.get(A.class);
 			}
 		});

--- a/src/test/java/BenchmarkTest.java
+++ b/src/test/java/BenchmarkTest.java
@@ -18,17 +18,16 @@ import org.springframework.context.ApplicationContext;
 
 import com.github.drinkjava2.BeanBoxContext;
 import com.google.inject.Injector;
+import com.greenlaw110.di_benchmark.DIFactory.DaggerComponent;
 import com.greenlaw110.di_benchmark.DIFactory.VanillaContainer;
 import com.greenlaw110.di_benchmark.objects.A;
-
-import dagger.ObjectGraph;
 
 public class BenchmarkTest extends Assert {
 
 	static VanillaContainer vanilla;
 	static Injector guice;
 	static Feather feather;
-	static ObjectGraph dagger;
+	static DaggerComponent dagger;
 	static PicoContainer pico;
 	static Genie genie;
 	static ApplicationContext spring;


### PR DESCRIPTION
As @nilsonfreitas predicted, the results are pretty close to "vanilla".

Dagger 2 uses code generation, so the setup is more complicated than a simple Maven dependency.  The pom now includes ```dagger-compiler``` in ```<annotationProcessorPaths>```.  This feature requires Maven version 3.5.

Eclipse requires enabling annotation processor support installed and enabled. The m2e-apt plugin can be downloaded from the Eclipse Marketplace or https://marketplace.eclipse.org/content/m2e-apt (which also has configuration instructions). Ensure that Preferences -> Maven -> Annotation Processing is set to "Automatically configure JDT APT" or this will not work. (hat tip to @ravn for https://github.com/ravn/dagger2-hello-world)

```
Starting up DI containers & instantiating a dependency graph 4999 times:
------------------------------------------------------------------------
                     Vanilla|     1ms
                       Guice|   532ms
                     Feather|    42ms
                      Dagger|     3ms
                        Pico|   246ms
                       Genie|   211ms
          jBeanBoxAnnotation|   469ms
            jBeanBoxTypeSafe|   134ms
              jBeanBoxNormal|   202ms
     SpringJavaConfiguration| 12716ms
     SpringAnnotationScanned| 32256ms

Runtime benchmark, fetch new bean for 49999 times:
---------------------------------------------------------
                     Vanilla|     2ms
                       Guice|   133ms
                     Feather|    47ms
                      Dagger|     4ms
                       Genie|    47ms
                        Pico|   259ms
              jBeanBoxNormal|  1444ms
            jBeanBoxTypeSafe|   774ms
          jBeanBoxAnnotation|  2063ms
     SpringJavaConfiguration|  1493ms
     SpringAnnotationScanned|  1786ms
```

I added a small shim in ```DaggerComponent``` that dispatches ```get(Class)``` to ```getA()``` and ```getA0()```.  That would account for some of the performance penalty compared to vanilla.  In most applications, such a shim would be unnecessary.

```java
        @SuppressWarnings("unchecked")
        default <T> T get(Class<T> c) {
            if (c == A.class) {
                return (T) getA();
            }
            if (c == A0.class) {
                return (T) getA0();
            }
            throw new IllegalArgumentException();
        }
```